### PR TITLE
Support ${workspaceRoot} in include dirs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,6 +119,11 @@ class IncludeCompletionProvider implements vscode.CompletionItemProvider, vscode
       }
     }
 
+    // Support ${workspaceRoot}
+    for (var i = 0; i < dirs.length; i++) {
+      dirs[i] = dirs[i].replace("${workspaceRoot}", vscode.workspace.rootPath);
+    }
+
     this.dirs = dirs;
   }
 


### PR DESCRIPTION
Adds support for ${workspaceRoot} in c_cpp_properties.json include dirs.